### PR TITLE
VirtualItem no enchants item fix

### DIFF
--- a/src/main/java/me/fromgate/reactions/util/item/VirtualItem.java
+++ b/src/main/java/me/fromgate/reactions/util/item/VirtualItem.java
@@ -56,6 +56,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.Nullable;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
@@ -361,6 +362,19 @@ public class VirtualItem extends ItemStack {
         ItemMeta im = this.getItemMeta();
         if (im.hasLore()) return im.getLore();
         return null;
+    }
+
+    @Override
+    public boolean isSimilar(@Nullable ItemStack stack) {
+        if (stack == null) return false;
+
+        if (this.getEnchantments().isEmpty()) {
+            ItemStack clonedStack = stack.clone();
+            clonedStack.getEnchantments().forEach((enchantment, integer) -> clonedStack.removeEnchantment(enchantment));
+            return super.isSimilar(clonedStack);
+        }
+
+        return super.isSimilar(stack);
     }
 
     public void setLore(String loreStr) {


### PR DESCRIPTION
We use REMOVE_INVENTORY_ITEM and we can not specify that item should not be enchanted. This fix will ignore all enchants of an item if none are specified in VirtualItem.
This will be removed from inventory
![image](https://user-images.githubusercontent.com/87545780/130056137-aba7c4e3-a8ab-4658-adc7-9d7b50af0e8a.png)

This will not be removed from inventory
![image](https://user-images.githubusercontent.com/87545780/130056188-575469f3-03ad-4fd2-830b-a515f36c82da.png)
